### PR TITLE
PJ_SIM_CHATGPT_2023-6 Add Notification for error handling

### DIFF
--- a/src/providers/SidebarProvider.ts
+++ b/src/providers/SidebarProvider.ts
@@ -67,6 +67,9 @@ export class SidebarProvider implements vscode.WebviewViewProvider {
                   `\n${res.data.choices[0].message?.content}`
                 );
               });
+            }
+            ).catch(error => {
+             vscode.window.showErrorMessage('SIM ChatGPT: ' + error.response.data.error.message || error.message);
             });
           break;
         }


### PR DESCRIPTION
## Links
https://framgiaph.backlog.com/board/PJ_SIM_CHATGPT_2023?selectedIssueKey=PJ_SIM_CHATGPT_2023-6
## Description
if the API key is expired or by any chance, not usable anymore. Prompt a notification on bottom right with the error 403 or forbidden access.
## Notes
N/A
## Screenshots
![image](https://github.com/roseaugusto/pj_sim-chatgpt/assets/106945745/d6889638-b0b7-44a4-9bb7-27ee81fdb11a)
