### PR TITLE
PJ_SIM_CHATGPT_2023-12 Improvement: Add pre-commit configuration

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,4 @@
+node_modules
+.github
+\*.config.js
+\*.tsbuildinfo

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,26 @@
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks.git
+    rev: v4.3.0
+    hooks:
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
+  - repo: https://github.com/pre-commit/mirrors-prettier
+    rev: v2.7.1
+    hooks:
+      - id: prettier
+        files: ^src/.*\.(ts|tsx|js|css|html|json)$|^media/.*\.(ts|tsx|js|css|html|json)
+        args: ['--config=./.prettierrc', '--ignore-path=./.prettierignore']
+  - repo: https://github.com/pre-commit/mirrors-eslint
+    rev: 'v8.33.0'
+    hooks:
+      - id: eslint
+        additional_dependencies:
+          - eslint
+          - typescript
+          - '@typescript-eslint/parser'
+          - '@typescript-eslint/eslint-plugin'
+          - eslint-config-prettier
+          - eslint-plugin-prettier
+        files: ^src/.*\.[jt]sx?$
+        types: [file]
+        args: ['--config=./.eslintrc.json', '--ignore-path=./.eslintignore']

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,5 @@
+**/.git
+**/.svn
+**/.hg
+**/node_modules
+**/*.md


### PR DESCRIPTION
## Links
https://framgiaph.backlog.com/view/PJ_SIM_CHATGPT_2023-12
## Description
* Implement Pre-commit configuration:
    * Formatter
    * Linter
    * End of line fixer
## Notes
- Check your system if python is installed and install it if not yet exists. This is a dependency to install pre-commit using pip
- Run `pip install pre-commit`
- Run `pre-commit install` to load pre-commit config on your git. This will run every time you push a commit.
## Screenshots
![image](https://github.com/roseaugusto/pj_sim-chatgpt/assets/110364637/cd4d05e5-08db-40c4-a1e9-b6e24e4c4119)
