### PR TITLE
PJ_SIM_CHATGPT_2023-10 Improvement: Additional FE Testing Framework

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,6 +56,22 @@
         {
           "command": "sim-chatgpt-unit-test.runAVA",
           "group": "navigation"
+        },
+        {
+          "command": "sim-chatgpt-unit-test.runCypress",
+          "group": "navigation"
+        },
+        {
+          "command": "sim-chatgpt-unit-test.runStorybook",
+          "group": "navigation"
+        },
+        {
+          "command": "sim-chatgpt-unit-test.runPuppeteer",
+          "group": "navigation"
+        },
+        {
+          "command": "sim-chatgpt-unit-test.runPlaywright",
+          "group": "navigation"
         }
       ]
     },
@@ -98,6 +114,22 @@
       {
         "command": "sim-chatgpt-unit-test.runAVA",
         "title": "AVA"
+      },
+      {
+        "command": "sim-chatgpt-unit-test.runCypress",
+        "title": "Cypress"
+      },
+      {
+        "command": "sim-chatgpt-unit-test.runPuppeteer",
+        "title": "Puppeteer"
+      },
+      {
+        "command": "sim-chatgpt-unit-test.runStorybook",
+        "title": "Storybook"
+      },
+      {
+        "command": "sim-chatgpt-unit-test.runPlaywright",
+        "title": "Playwright"
       }
     ]
   },

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -63,6 +63,30 @@ export async function activate(context: vscode.ExtensionContext) {
   );
   context.subscriptions.push(avaCommandDisposable);
 
+  const cypressCommandDisposable = vscode.commands.registerCommand(
+    'sim-chatgpt-unit-test.runCypress',
+    () => runUnitTestCommand('Cypress')
+  );
+  context.subscriptions.push(cypressCommandDisposable);
+
+  const storybookCommandDisposable = vscode.commands.registerCommand(
+    'sim-chatgpt-unit-test.runStorybook',
+    () => runUnitTestCommand('Storybook')
+  );
+  context.subscriptions.push(storybookCommandDisposable);
+
+  const puppeteerCommandDisposable = vscode.commands.registerCommand(
+    'sim-chatgpt-unit-test.runPuppeteer',
+    () => runUnitTestCommand('Puppeteer')
+  );
+  context.subscriptions.push(puppeteerCommandDisposable);
+
+  const playwrightCommandDisposable = vscode.commands.registerCommand(
+    'sim-chatgpt-unit-test.runPlaywright',
+    () => runUnitTestCommand('Playwright')
+  );
+  context.subscriptions.push(playwrightCommandDisposable);
+
   vscode.window.onDidChangeTextEditorSelection((event) => {
     if (event.kind !== vscode.TextEditorSelectionChangeKind.Mouse) {
       return;


### PR DESCRIPTION
## Links
https://framgiaph.backlog.com/view/PJ_SIM_CHATGPT_2023-10
## Description
* Research additional widely used FE testing framework
* Implement and add the researched testing framework on the Unit Testing selection of the vscode extension to provide more options for users
  - Cypress
  - Storybook
  - Puppeteer
  - Playwright
## Notes
N/A
## Screenshots
![image](https://github.com/roseaugusto/pj_sim-chatgpt/assets/110364637/c973c082-1440-48b9-b8fd-ec11f6f1d0e7)
