### PR TITLE
PJ_SIM_CHATGPT_2023-11 Improvement: Additional BE Testing Framework

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,6 +72,17 @@
         {
           "command": "sim-chatgpt-unit-test.runPlaywright",
           "group": "navigation"
+        },{
+          "command": "sim-chatgpt-unit-test.runPHPUnit",
+          "group": "navigation"
+        },
+        {
+          "command": "sim-chatgpt-unit-test.runPyTest",
+          "group": "navigation"
+        },
+        {
+          "command": "sim-chatgpt-unit-test.runRSpec",
+          "group": "navigation"
         }
       ]
     },
@@ -130,6 +141,18 @@
       {
         "command": "sim-chatgpt-unit-test.runPlaywright",
         "title": "Playwright"
+      },
+      {
+        "command": "sim-chatgpt-unit-test.runPHPUnit",
+        "title": "PHPUnit   "
+      },
+      {
+        "command": "sim-chatgpt-unit-test.runPyTest",
+        "title": "PyTest"
+      },
+      {
+        "command": "sim-chatgpt-unit-test.runRSpec",
+        "title": "RSpec"
       }
     ]
   },

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -86,6 +86,23 @@ export async function activate(context: vscode.ExtensionContext) {
     () => runUnitTestCommand('Playwright')
   );
   context.subscriptions.push(playwrightCommandDisposable);
+  const phpUnitCommandDisposable = vscode.commands.registerCommand(
+    'sim-chatgpt-unit-test.runPHPUnit',
+    () => runUnitTestCommand('PHPUnit')
+  );
+  context.subscriptions.push(phpUnitCommandDisposable);
+
+  const rspecCommandDisposable = vscode.commands.registerCommand(
+    'sim-chatgpt-unit-test.runRSpec',
+    () => runUnitTestCommand('RSpec')
+  );
+  context.subscriptions.push(rspecCommandDisposable);
+
+  const pyTestCommandDisposable = vscode.commands.registerCommand(
+    'sim-chatgpt-unit-test.runPyTest',
+    () => runUnitTestCommand('PyTest')
+  );
+  context.subscriptions.push(pyTestCommandDisposable);
 
   vscode.window.onDidChangeTextEditorSelection((event) => {
     if (event.kind !== vscode.TextEditorSelectionChangeKind.Mouse) {


### PR DESCRIPTION
## Links
https://framgiaph.backlog.com/board/PJ_SIM_CHATGPT_2023?selectedIssueKey=PJ_SIM_CHATGPT_2023-11
## Description
* Research additional widely used BE testing framework
* Implement and add the researched testing framework on the Unit Testing selection of the vscode extension to provide more options for users
  - PHPUnit
  - RSpec
  - PyTest

## Notes
 N/A

## Screenshots
![image](https://github.com/roseaugusto/pj_sim-chatgpt/assets/106945745/ef9acb4e-606a-446a-af38-da18bfd36ed7)
