### PR TITLE
PJ_SIM_CHATGPT_2023-28 Unit Test Improvement: Put set timeout on pop notification

### DIFF
--- a/src/components/ToastMessage.ts
+++ b/src/components/ToastMessage.ts
@@ -1,0 +1,42 @@
+import * as vscode from 'vscode';
+
+export const showMessageWithTimeout = (
+  type: 'success' | 'warn' | 'error',
+  message: string,
+  timeout: number = 5
+): void => {
+  void vscode.window.withProgress(
+    {
+      location: vscode.ProgressLocation.Notification,
+      title: `${mapMessageType(type)}: ${message}`,
+      cancellable: true,
+    },
+    async (progress: any): Promise<void> => {
+      for (let i = 0; i < timeout; i++) {
+        progress.report({
+          increment: i + 100 / timeout,
+        });
+        await sleep(1000);
+      }
+    }
+  );
+};
+
+export const sleep = (ms: number): Promise<unknown> => {
+  return new Promise((resolve) => {
+    return setTimeout(resolve, ms);
+  });
+};
+
+export const mapMessageType = (type: string): string => {
+  let messageType = '❌ ERROR';
+  switch (type) {
+    case 'success':
+      messageType = '✅ SUCCESS';
+      break;
+    case 'warn':
+      messageType = '⚠️ WARNING';
+      break;
+  }
+  return messageType;
+};

--- a/src/providers/SidebarProvider.ts
+++ b/src/providers/SidebarProvider.ts
@@ -2,6 +2,7 @@ import * as vscode from 'vscode';
 import * as openai from 'openai';
 import * as fs from 'fs';
 import * as moment from 'moment';
+import { showMessageWithTimeout } from '../components/ToastMessage';
 
 export class SidebarProvider implements vscode.WebviewViewProvider {
   _view?: vscode.WebviewView;
@@ -66,7 +67,8 @@ export class SidebarProvider implements vscode.WebviewViewProvider {
                 type: 'onLoadApiKey',
                 value: apiKey,
               });
-              vscode.window.showInformationMessage(
+              showMessageWithTimeout(
+                'success',
                 'SIM ChatGPT successfully added API key: ' + data.value
               );
             } else {
@@ -77,7 +79,7 @@ export class SidebarProvider implements vscode.WebviewViewProvider {
               error.response?.data?.error?.message ||
               error.message ||
               'Unknown error occurred';
-            vscode.window.showErrorMessage('SIM ChatGPT: ' + errorMessage);
+            showMessageWithTimeout('error', errorMessage);
             this._view?.webview.postMessage({
               type: 'onLoadApiKey',
               value: undefined,
@@ -140,9 +142,9 @@ export class SidebarProvider implements vscode.WebviewViewProvider {
                   value: error.response.data.error.message,
                 });
               }
-              vscode.window.showErrorMessage(
-                'SIM ChatGPT: ' + error.response.data.error.message ||
-                  error.message
+              showMessageWithTimeout(
+                'error',
+                error.response.data.error.message || error.message
               );
               this._isCancelled = false;
             });


### PR DESCRIPTION

## Links
https://framgiaph.backlog.com/view/PJ_SIM_CHATGPT_2023-28
## Description
- Put set timeout on pop notification
- Used withProgress
## Notes
- As of the moment, I opt to use `withProgress `  since it is the only one window type where we can dynamically add timeout and programmatically dismiss the window as a notification. However, one downside is that is only has fixed design/output which is an `information window`. We cannot yet override its design and icon used such as an error or warning, at the moment based on my research
- As a workaround, I just appended an emoji icons to the message itself to represent success, warning and error messages
- References: 
   - https://www.eliostruyf.com/creating-timer-dismissable-notifications-visual-studio-code-extension/
   - https://github.com/microsoft/vscode/issues/94295#issuecomment-608259389
## Screenshots

https://github.com/roseaugusto/pj_sim-chatgpt/assets/110364637/312d6514-c7fe-4872-87c8-76698ff39125

