### PR TITLE
PJ_SIM_CHATGPT_2023-43 Unit Test Improvement: Add prompt to input test directory and test filename

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -11,8 +11,19 @@ export async function activate(context: vscode.ExtensionContext) {
 
   const runUnitTestCommand = async (type: string) => {
     await vscode.commands.executeCommand('sim-chatgpt-sidebar.focus');
-    setTimeout(() => {
+
+    setTimeout(async () => {
       sidebarProvider._view?.show();
+
+      // Utilize this `unitTestPathname` variable to create the file alongside the path to the test folder
+      const unitTestPathname = await vscode.window.showInputBox({
+        placeHolder: 'Search query',
+        prompt:
+          'Input filename with full path to your test folder (e.g. c:\\<path-to-project>\\src\\tests)',
+        value: vscode.workspace.workspaceFolders?.[0].uri.fsPath as string,
+        ignoreFocusOut: true,
+      });
+
       const editor = vscode.window.activeTextEditor;
       const selection = editor?.selection;
       const highlightedText = editor?.document.getText(selection);


### PR DESCRIPTION


## Links
https://framgiaph.backlog.com/view/PJ_SIM_CHATGPT_2023-43
## Description
- Add prompt to input test directory and test filename
- Get current workspace folder path
## Notes
- An input prompt will appear after you click any test framework and input the path to your test folder and file name there
## Screenshots
![image](https://github.com/roseaugusto/pj_sim-chatgpt/assets/110364637/de4ad1c9-5d71-452b-97ae-acbb9a9edc31)
