### PR TITLE
PJ_SIM_CHATGPT_2023-48 Unit Test Improvement: Add pathname error handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,5 +48,12 @@ Update list of testing frameworks and resolve API Key navigation
 - Replaced API Key input caption to actual details
 - Persist inputs and loading when leaving and going back to the extension
 - Add dialog box on GPT response output
+### 1.0.3
+
+- Format response with codeblocks
+- Generate separate file for each unit test result
+### 1.0.4
+
+- Add error handling on pathname input field
 
 **Enjoy!**

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "icon": "media/icons/logo.png",
   "description": "",
-  "version": "1.0.2",
+  "version": "1.0.4",
   "engines": {
     "vscode": "^1.78.0"
   },

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,5 +1,6 @@
 import * as vscode from 'vscode';
 import { SidebarProvider } from './providers/SidebarProvider';
+import { showMessageWithTimeout } from './components/ToastMessage';
 
 export async function activate(context: vscode.ExtensionContext) {
   const sidebarProvider = new SidebarProvider(context);
@@ -14,15 +15,21 @@ export async function activate(context: vscode.ExtensionContext) {
 
     setTimeout(async () => {
       sidebarProvider._view?.show();
+      let unitTestPathname: string | undefined = '';
+      const regex = /\.(js|ts|php|rb|py|tsx|jsx)$/i;
 
-      // Utilize this `unitTestPathname` variable to create the file alongside the path to the test folder
-      const unitTestPathname = await vscode.window.showInputBox({
-        placeHolder: 'Search query',
-        prompt:
-          'Input filename with full path to your test folder (e.g. c:\\<path-to-project>\\src\\tests)',
-        value: vscode.workspace.workspaceFolders?.[0].uri.fsPath as string,
-        ignoreFocusOut: true,
-      });
+      do {
+        unitTestPathname = await vscode.window.showInputBox({
+          placeHolder: 'Search query',
+          prompt:
+            'Input filename with full path to your test folder (e.g. c:\\<path-to-project>\\src\\tests)',
+          value: vscode.workspace.workspaceFolders?.[0].uri.fsPath as string,
+          ignoreFocusOut: true,
+        });
+        if (!regex.test(unitTestPathname as string)) {
+          showMessageWithTimeout('error', 'The provided pathname is not valid');
+        }
+      } while (!regex.test(unitTestPathname as string));
 
       const editor = vscode.window.activeTextEditor;
       const selection = editor?.selection;


### PR DESCRIPTION
## Links
https://framgiaph.backlog.com/view/PJ_SIM_CHATGPT_2023-48
## Description
Add pathname error handling
Check is pathname ends with an extension
## Notes
Test by not specifying filename extension and it should prompt again with error message
## Screenshots

https://github.com/roseaugusto/pj_sim-chatgpt/assets/110364637/ce226adf-011c-406b-bdd1-b11d81ad88c6

